### PR TITLE
Remove issue number from backport title to save space for the main ti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const example = async () => {
     // Defaults to: "Backport #{pullRequestNumber}."
     body: givenBody,
     // The name to give to the head branch of the backported pull request.
-    // Defaults to: "backport-{pullRequestNumber}-on-{base}"
+    // Defaults to: "backport-{pullRequestNumber}-to-{base}"
     head: givenHead,
     // An already authenticated instance of https://www.npmjs.com/package/@octokit/rest.
     octokit,
@@ -30,7 +30,7 @@ const example = async () => {
     // The name of the repository.
     repo,
     // The title to give to the backported pull request.
-    // Defaults to: "Backport #{pullRequestNumber} on {base}: {original pull request title}"
+    // Defaults to: "[Backport to {base}] {original pull request title}"
     title: givenTitle,
   });
 };
@@ -80,22 +80,22 @@ and a pull request numbered `#1337` where `dev` is the base branch and `feature`
 To backport `#1337` to `master`, `github-backport` would then take the following steps:
 
 1.  Find out that `#1337` is composed of `8a846f6` and `0d40af8` with [GET /repos/:owner/:repo/pulls/:number/commits](https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request).
-2.  Create a `backport-1337-on-master` branch from `master` with [POST /repos/:owner/:repo/git/refs](https://developer.github.com/v3/git/refs/#create-a-reference).
+2.  Create a `backport-1337-to-master` branch from `master` with [POST /repos/:owner/:repo/git/refs](https://developer.github.com/v3/git/refs/#create-a-reference).
     <!--
-    git checkout -b backport-1337-on-master
+    git checkout -b backport-1337-to-master
     -->
     ```
     * 0d40af8 (feature) D
     * 8a846f6 C
     * b3c3b70 (dev) B
-    * 55356b7 (HEAD -> backport-1337-on-master, master) A
+    * 55356b7 (HEAD -> backport-1337-to-master, master) A
     ```
-3.  Cherry-pick `8a846f6` and `0d40af8` on `backport-1337-on-master` with [`github-cherry-pick`](https://www.npmjs.com/package/github-cherry-pick).
+3.  Cherry-pick `8a846f6` and `0d40af8` to `backport-1337-to-master` with [`github-cherry-pick`](https://www.npmjs.com/package/github-cherry-pick).
     <!--
     git cherry-pick 8a846f6 0d40af8
     -->
     ```
-    * 1ec51e5 (HEAD -> backport-1337-on-master) D
+    * 1ec51e5 (HEAD -> backport-1337-to-master) D
     * e99200a C
     | * 0d40af8 (feature) D
     | * 8a846f6 C
@@ -103,7 +103,7 @@ To backport `#1337` to `master`, `github-backport` would then take the following
     |/
     * 55356b7 (master) A
     ```
-4.  Create a pull request where `master` is the base branch and `backport-1337-on-master` the head branch with [POST /repos/:owner/:repo/pulls](https://developer.github.com/v3/pulls/#create-a-pull-request).
+4.  Create a pull request where `master` is the base branch and `backport-1337-to-master` the head branch with [POST /repos/:owner/:repo/pulls](https://developer.github.com/v3/pulls/#create-a-pull-request).
 
 ## Atomicity
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To backport `#1337` to `master`, `github-backport` would then take the following
     * b3c3b70 (dev) B
     * 55356b7 (HEAD -> backport-1337-to-master, master) A
     ```
-3.  Cherry-pick `8a846f6` and `0d40af8` to `backport-1337-to-master` with [`github-cherry-pick`](https://www.npmjs.com/package/github-cherry-pick).
+3.  Cherry-pick `8a846f6` and `0d40af8` on `backport-1337-to-master` with [`github-cherry-pick`](https://www.npmjs.com/package/github-cherry-pick).
     <!--
     git cherry-pick 8a846f6 0d40af8
     -->

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "test": "jest",
     "tslint": "tslint --format stylish --project ."
   },
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -90,7 +90,7 @@ describe("nominal behavior", () => {
       repo,
     });
     givenBody = `Backport #${featurePullRequestNumber}.`;
-    givenTitle = `Backport #${featurePullRequestNumber} on ${givenBase}`;
+    givenTitle = `Backport #${featurePullRequestNumber} to ${givenBase}`;
     backportedPullRequestNumber = await backportPullRequest({
       base: givenBase,
       body: givenBody,
@@ -134,7 +134,7 @@ describe("nominal behavior", () => {
 
   test("head default is respected", () => {
     expect(actualHead).toBe(
-      `backport-${featurePullRequestNumber}-on-${givenBase}`,
+      `backport-${featurePullRequestNumber}-to-${givenBase}`,
     );
   });
 
@@ -215,7 +215,7 @@ describe("atomicity", () => {
   });
 
   test("whole operation aborted when the commits cannot be cherry-picked", async () => {
-    const head = `backport-${featurePullRequestNumber}-on-${
+    const head = `backport-${featurePullRequestNumber}-to-${
       refsDetails.dev.ref
     }`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const backportPullRequest = async ({
   const {
     body = `Backport #${pullRequestNumber}.`,
     head = `backport-${pullRequestNumber}-on-${base}`,
-    title = `Backport #${pullRequestNumber} on ${base}: ${originalTitle}`,
+    title = `Backport (${base}): ${originalTitle}`,
   } = { body: givenBody, head: givenHead, title: givenTitle };
 
   debug("starting", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,8 @@ const backportPullRequest = async ({
 
   const {
     body = `Backport #${pullRequestNumber}.`,
-    head = `backport-${pullRequestNumber}-on-${base}`,
-    title = `Backport (${base}): ${originalTitle}`,
+    head = `backport-${pullRequestNumber}-to-${base}`,
+    title = `[Backport ${base}] ${originalTitle}`,
   } = { body: givenBody, head: givenHead, title: givenTitle };
 
   debug("starting", {


### PR DESCRIPTION
…tle because long titles already have a lot of meaningful information which is too bad when it's cut and hidden inside the body