### PR TITLE
Preserve original http error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,11 +105,15 @@ const backportPullRequest = async ({
       debug("commits cherry-picked", headSha);
     } catch (error) {
       debug("commits could not be cherry-picked", error);
-      throw new Error(
+      const newError = new Error(
         `Commits ${JSON.stringify(
           commits,
         )} could not be cherry-picked on top of ${base}`,
       );
+      if(error.name === "HttpError") {
+        newError.httpError = error
+      }
+      throw newError;
     }
     debug("creating pull request");
     const {


### PR DESCRIPTION
Currently when a merge conflict occurs an error is thrown like:
```
Commits ["f092752cbb34737fe84262aa02d42945ee79eaa8"] could not be cherry-picked on top of 7.x
```

Would be great if the original http error from Octokit was available also.
